### PR TITLE
Add login_required to dashboard_data route

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,6 +177,7 @@ def admin_dashboard():
     )
 
 @app.route('/dashboard_data', methods=['POST'])
+@login_required()
 def dashboard_data():
     data = request.get_json()
     user_id = data.get('user_id')


### PR DESCRIPTION
## Summary
- secure `dashboard_data` endpoint by requiring login

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68668690e2d0832db0d37a6d3d781448