### PR TITLE
Fix treatment plan variable in patient report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 
 firebase_key.json
+service_account.json

--- a/templates/patient_report.html
+++ b/templates/patient_report.html
@@ -34,7 +34,7 @@
         <p>{{ goals['patient_goal'] if goals else 'Not Filled' }}</p>
 
         <h3>Treatment Plan</h3>
-        <p>{{ treatment['treatment'] if treatment else 'Not Filled' }}</p>
+        <p>{{ treatment['treatment_plan'] if treatment else 'Not Filled' }}</p>
 
     </div>
 </body>


### PR DESCRIPTION
## Summary
- update patient report to show `treatment_plan`
- ignore `service_account.json` to avoid committing credentials

## Testing
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68676618b614832d9e9f3ed02d42357d