### PR TITLE
Fix Firestore client init in app

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,11 +5,9 @@ from functools import wraps
 from werkzeug.security import generate_password_hash, check_password_hash
 from firebase_init import firebase_admin  # uses your existing setup
 from firebase_admin import firestore
-db = firestore.client()
 import anthropic
 import firebase_admin
 from firebase_admin import credentials, firestore
-import os
 
 if not firebase_admin._apps:
     cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")


### PR DESCRIPTION
## Summary
- clean up duplicate `os` import
- remove early Firestore client creation
- keep single Firestore client after firebase initialization

## Testing
- `python -m py_compile app.py`
- `python app.py` *(server started then was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686768604398832da4b8e067fcc42c0f