### PR TITLE
Simplify Firebase initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,16 +3,9 @@ from flask import Flask, render_template, request, redirect, session, url_for, m
 import io, csv
 from functools import wraps
 from werkzeug.security import generate_password_hash, check_password_hash
-from firebase_init import firebase_admin  # uses your existing setup
+from firebase_init import firebase_admin  # initializes on import
 from firebase_admin import firestore
 import anthropic
-import firebase_admin
-from firebase_admin import credentials, firestore
-
-if not firebase_admin._apps:
-    cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-    cred = credentials.Certificate(cred_path)
-    firebase_admin.initialize_app(cred)
 
 db = firestore.client()
 


### PR DESCRIPTION
## Summary
- rely on `firebase_init.py` for Firebase setup via `FIREBASE_KEY`
- remove manual initialization logic from `app.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68676990b190832d854ed4bb3e26bcfa