### PR TITLE
Require SECRET_KEY configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,10 @@ def log_action(user_id, action, details=None):
     })
 
 app = Flask(__name__)
-app.secret_key = os.environ.get('SECRET_KEY', 'fallback_default')
+secret_key = os.environ.get('SECRET_KEY')
+if not secret_key:
+    raise RuntimeError('SECRET_KEY environment variable is required')
+app.secret_key = secret_key
 
 
 def login_required(approved_only=True):

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,11 @@ Hosting Environment:
 - Developed and tested on Replit (Python Flask)
 - SQLite as the database engine
 
+Configuration:
+- The Flask application requires the `SECRET_KEY` environment variable.
+  Set this to a secure, random string before starting the server or the
+  application will fail to launch.
+
 Planned Enhancements:
 - Mobile App version
 - Google Drive / OneDrive integration


### PR DESCRIPTION
## Summary
- fail fast if `SECRET_KEY` isn't set
- note the required environment variable in the README

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68676a5206f0832d9a78cdaff2b1f8ae