### PR TITLE
Add FLASK_DEBUG flag support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1879,4 +1879,6 @@ Keep analysis practical and actionable for immediate clinical use.
         return jsonify({"error": "AI session insights failed"}), 500
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_env = os.getenv("FLASK_DEBUG", "false")
+    debug_mode = str(debug_env).lower() in ("1", "true", "yes", "on")
+    app.run(debug=debug_mode)

--- a/render.yaml
+++ b/render.yaml
@@ -7,3 +7,5 @@ services:
     envVars:
       - key: FLASK_ENV
         value: production
+      - key: FLASK_DEBUG
+        value: "0"


### PR DESCRIPTION
## Summary
- make `app.run` debug mode configurable via `FLASK_DEBUG`
- set default `FLASK_DEBUG` flag in `render.yaml`

## Testing
- `python -m py_compile app.py`
- `python -m py_compile firebase_init.py notifications.py init_db.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68676af5bc24832db3485a8cc9b6ae0f