### PR TITLE
Add CSRF protection via Flask-WTF

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from functools import wraps
 from werkzeug.security import generate_password_hash, check_password_hash
 from firebase_init import firebase_admin  # initializes on import
 from firebase_admin import firestore
+from flask_wtf import CSRFProtect
 import anthropic
 
 db = firestore.client()
@@ -43,6 +44,7 @@ secret_key = os.environ.get('SECRET_KEY')
 if not secret_key:
     raise RuntimeError('SECRET_KEY environment variable is required')
 app.secret_key = secret_key
+csrf = CSRFProtect(app)
 
 
 def login_required(approved_only=True):
@@ -1094,6 +1096,7 @@ def get_cumulative_patient_data(patient_id):
 
 # ENHANCED AI ENDPOINTS - Replace your existing ones with these:
 
+@csrf.exempt
 @app.route("/api/ai/subjective-exam", methods=["POST"])
 @login_required()
 def ai_subjective_exam():
@@ -1132,6 +1135,7 @@ Provide single-line clinical statements for each section.
     except Exception as e:
         return jsonify({"error": "AI analysis failed"}), 500
 
+@csrf.exempt
 @app.route("/api/ai/patient-perspectives", methods=["POST"])
 @login_required()
 def ai_patient_perspectives():
@@ -1176,6 +1180,7 @@ Write each as a one-line clinical interpretation.
     except Exception as e:
         return jsonify({"error": "AI analysis failed"}), 500
 
+@csrf.exempt
 @app.route("/api/ai/initial-plan", methods=["POST"])
 @login_required()
 def ai_initial_plan():
@@ -1223,6 +1228,7 @@ Provide responses as concise bullet points.
     except Exception as e:
         return jsonify({"error": "AI analysis failed"}), 500
 
+@csrf.exempt
 @app.route("/api/ai/pathophysiological", methods=["POST"])
 @login_required()
 def ai_pathophysiological():
@@ -1274,6 +1280,7 @@ Keep clinical and evidence-based.
     except Exception as e:
         return jsonify({"error": "AI analysis failed"}), 500
 
+@csrf.exempt
 @app.route("/api/ai/clinical-flags", methods=["POST"])
 @login_required()
 def ai_clinical_flags():
@@ -1329,6 +1336,7 @@ Provide specific reasoning for each flag based on the clinical data.
     except Exception as e:
         return jsonify({"error": "AI analysis failed"}), 500
 
+@csrf.exempt
 @app.route("/api/ai/provisional-diagnosis", methods=["POST"])
 @login_required()
 def ai_provisional_diagnosis():
@@ -1396,6 +1404,7 @@ Format as structured clinical reasoning.
     except Exception as e:
         return jsonify({"error": "AI analysis failed"}), 500
 
+@csrf.exempt
 @app.route("/api/ai/smart-goals", methods=["POST"])
 @login_required()
 def ai_smart_goals():
@@ -1460,6 +1469,7 @@ Format as practical, patient-centered SMART goals.
     except Exception as e:
         return jsonify({"error": "AI analysis failed"}), 500
 
+@csrf.exempt
 @app.route("/api/ai/treatment-plan", methods=["POST"])
 @login_required()
 def ai_treatment_plan():
@@ -1557,6 +1567,7 @@ Format as a structured, evidence-based treatment plan ready for clinical impleme
 # ADD THESE FOLLOW-UP AI ENDPOINTS TO THE END OF YOUR APP.PY
 # (After your clinical workflow AI endpoints, before if __name__ == '__main__':)
 
+@csrf.exempt
 @app.route("/api/ai/followup-recommendations", methods=["POST"])
 @login_required()
 def ai_followup_recommendations():
@@ -1659,6 +1670,7 @@ Keep recommendations practical and specific to physiotherapy follow-up sessions.
         print(f"AI follow-up recommendations error: {str(e)}")
         return jsonify({"error": "AI recommendations failed"}), 500
 
+@csrf.exempt
 @app.route("/api/ai/followup-progress-analysis", methods=["POST"])
 @login_required()
 def ai_followup_progress_analysis():
@@ -1782,6 +1794,7 @@ Provide specific, evidence-based analysis suitable for clinical decision-making.
         print(f"AI progress analysis error: {str(e)}")
         return jsonify({"error": "AI progress analysis failed"}), 500
 
+@csrf.exempt
 @app.route("/api/ai/followup-session-insights", methods=["POST"])
 @login_required()
 def ai_followup_session_insights():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,5 @@ dependencies = [
     "gunicorn==23.0.0",
     "firebase-admin==6.9.0",
     "anthropic==0.57.1",
+    "Flask-WTF==1.2.2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ cairocffi>=1.4.0
 gunicorn==23.0.0
 firebase-admin==6.9.0
 anthropic==0.57.1
+Flask-WTF==1.2.2

--- a/templates/add_patient.html
+++ b/templates/add_patient.html
@@ -69,6 +69,7 @@
         </div>
 
         <form method="POST">
+            {{ csrf_token() }}
             <label>Patient Name:</label>
             <input class="input-field" type="text" name="name" id="name" required>
 

--- a/templates/approve_physios.html
+++ b/templates/approve_physios.html
@@ -24,6 +24,7 @@
                         <a href="/approve_user/{{ physio['id'] }}">
                             <button class="button">Approve</button>
                             <form action="/reject_user/{{ physio['id'] }}" method="get" style="display:inline;">
+                                {{ csrf_token() }}
                                 <button class="button" style="background-color: crimson;">Reject</button>
                             </form>
 

--- a/templates/chronic_disease.html
+++ b/templates/chronic_disease.html
@@ -73,6 +73,7 @@
         </div>
 
         <form method="POST">
+            {{ csrf_token() }}
             <div class="form-group">
                 <label for="cause">Cause for Maintenance of Symptoms:</label>
                 <div class="field-with-ai">

--- a/templates/clinical_flags.html
+++ b/templates/clinical_flags.html
@@ -79,6 +79,7 @@
     </div>
 
     <form method="POST">
+    {{ csrf_token() }}
 
       <div class="flag-section red-flag">
         <label for="red_flag"><strong>🔴 Red Flag</strong> (Serious Pathology requiring further assessment or Medical/Surgical Intervention)</label>

--- a/templates/edit_patient.html
+++ b/templates/edit_patient.html
@@ -9,6 +9,7 @@
         <h2>Edit Patient Details - {{ patient['patient_id'] }}</h2>
 
         <form method="POST">
+            {{ csrf_token() }}
             <label>Name:</label>
             <input type="text" name="name" value="{{ patient['name'] }}" required><br>
 

--- a/templates/first_follow_up.html
+++ b/templates/first_follow_up.html
@@ -8,6 +8,7 @@
     <div class="container">
         <h2>First Follow-Up for {{ patient_id }}</h2>
         <form method="POST">
+            {{ csrf_token() }}
             <div class="form-group">
                 <label for="achievement">Grade of Achievement:</label>
                 <select name="achievement" id="achievement" class="input-field" required>

--- a/templates/follow_up_new.html
+++ b/templates/follow_up_new.html
@@ -68,6 +68,7 @@
         </div>
 
         <form method="POST">
+            {{ csrf_token() }}
             <label>Session Number:</label>
             <div class="field-with-ai">
                 <input type="text" name="session_number" id="session_number" class="input-field" required>

--- a/templates/initial_plan.html
+++ b/templates/initial_plan.html
@@ -73,6 +73,7 @@
         </div>
 
         <form method="POST">
+            {{ csrf_token() }}
             {% for section in [
                 ('active_movements', 'Active Movements'),
                 ('passive_movements', 'Passive Movements'),

--- a/templates/login.html
+++ b/templates/login.html
@@ -9,6 +9,7 @@
     <div class="container">
         <h2>Login</h2>
         <form method="POST">
+            {{ csrf_token() }}
             <input class="input-field" type="email" name="email" placeholder="Email" required>
             <input class="input-field" type="password" name="password" placeholder="Password" required>
             <button class="button" type="submit">Login</button>

--- a/templates/login_institute.html
+++ b/templates/login_institute.html
@@ -8,6 +8,7 @@
     <div class="container">
         <h2>Institute Login</h2>
         <form method="POST">
+            {{ csrf_token() }}
             <input class="input-field" type="email" name="email" placeholder="Email" required>
             <input class="input-field" type="password" name="password" placeholder="Password" required>
             <button class="button">Institute Login</button>

--- a/templates/objective_assessment.html
+++ b/templates/objective_assessment.html
@@ -73,6 +73,7 @@
     </div>
 
     <form method="POST">
+        {{ csrf_token() }}
         <label for="plan">Plan:</label>
         <div class="field-with-ai">
             <select name="plan" id="plan" class="input-field" required style="padding-right: 50px;">

--- a/templates/patho_mechanism.html
+++ b/templates/patho_mechanism.html
@@ -86,6 +86,7 @@
         </div>
 
         <form method="POST">
+            {{ csrf_token() }}
             <div class="form-grid">
 
                 <label for="area_involved">Area Involved:</label>

--- a/templates/perspectives.html
+++ b/templates/perspectives.html
@@ -69,6 +69,7 @@
     </div>
 
     <form method="POST" class="form-grid">
+    {{ csrf_token() }}
       <div class="form-group">
         <label for="knowledge">Knowledge of the Illness:</label>
         <div class="field-with-ai">

--- a/templates/provisional_diagnosis.html
+++ b/templates/provisional_diagnosis.html
@@ -72,6 +72,7 @@
         </div>
 
         <form method="POST">
+            {{ csrf_token() }}
             <label for="likelihood">Likelihood of Diagnosis:</label>
             <div class="field-with-ai">
                 <textarea name="likelihood" id="likelihood" class="input-field" rows="2" required style="padding-right: 50px;"></textarea>

--- a/templates/register.html
+++ b/templates/register.html
@@ -8,6 +8,7 @@
     <div class="container">
         <h2>Individual Physiotherapist Registration</h2>
         <form method="POST">
+            {{ csrf_token() }}
             <input class="input-field" type="text" name="name" placeholder="Full Name" required>
             <input class="input-field" type="email" name="email" placeholder="Email" required>
             <input class="input-field" type="text" name="phone" placeholder="Phone Number" required>

--- a/templates/register_institute.html
+++ b/templates/register_institute.html
@@ -8,6 +8,7 @@
     <div class="container">
         <h2>Register as Institute Admin</h2>
         <form method="POST">
+            {{ csrf_token() }}
             <input class="input-field" type="text" name="name" placeholder="Full Name" required>
             <input class="input-field" type="email" name="email" placeholder="Email" required>
             <input class="input-field" type="text" name="phone" placeholder="Phone Number" required>

--- a/templates/register_with_institute.html
+++ b/templates/register_with_institute.html
@@ -8,6 +8,7 @@
     <div class="container">
         <h2>Register as Institute Physiotherapist</h2>
         <form method="POST">
+            {{ csrf_token() }}
             <input class="input-field" type="text" name="name" placeholder="Full Name" required>
             <input class="input-field" type="email" name="email" placeholder="Email" required>
             <input class="input-field" type="text" name="phone" placeholder="Phone Number" required>

--- a/templates/smart_goals.html
+++ b/templates/smart_goals.html
@@ -83,6 +83,7 @@
         </div>
 
         <form method="POST">
+            {{ csrf_token() }}
 
             <label for="patient_goal">Goals (Patient-Centric):</label>
             <div class="field-with-ai">

--- a/templates/subjective.html
+++ b/templates/subjective.html
@@ -68,6 +68,7 @@
         </div>
 
         <form method="POST">
+            {{ csrf_token() }}
             <label>Impairment of body structure:</label>
             <div class="field-with-ai">
                 <textarea class="input-field" name="body_structure" id="body_structure" rows="2" required style="padding-right: 50px;"></textarea>

--- a/templates/treatment_plan.html
+++ b/templates/treatment_plan.html
@@ -68,6 +68,7 @@
         </div>
 
         <form method="POST">
+            {{ csrf_token() }}
             <label for="treatment_plan">Treatment Plan:</label>
             <div class="field-with-ai">
                 <textarea name="treatment_plan" id="treatment_plan" class="input-field" rows="2" required style="padding-right: 50px;"></textarea>

--- a/templates/view_patients.html
+++ b/templates/view_patients.html
@@ -82,6 +82,7 @@
 
         <!-- Filter Form -->
         <form method="GET" class="filter-form">
+            {{ csrf_token() }}
             <div style="display: flex; align-items: center; gap: 10px; flex-wrap: wrap;">
                 <label>Filter by Name:
                     <input type="text" name="name" placeholder="Enter Name">


### PR DESCRIPTION
## Summary
- integrate `Flask-WTF` CSRF protection in `app.py`
- exempt API endpoints from CSRF checks
- include `{{ csrf_token() }}` in every HTML form
- add Flask-WTF to dependencies

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68676f0cc298832dbb8992febcb8e402