### PR TITLE
Fix manage_users template active field

### DIFF
--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -21,14 +21,14 @@
                 <td>{{ user['email'] }}</td>
                 <td>{{ user['phone'] }}</td>
                 <td>
-                    {% if user['is_active'] %}
+                    {% if user['active'] %}
                         ✅ Active
                     {% else %}
                         ❌ Inactive
                     {% endif %}
                 </td>
                 <td>
-                    {% if user['is_active'] %}
+                    {% if user['active'] %}
                         <a href="/deactivate_user/{{ user['id'] }}">
                             <button style="background-color: crimson;">Deactivate</button>
                         </a>


### PR DESCRIPTION
## Summary
- use `active` instead of deprecated `is_active` field
- ensure activation buttons use `active`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68679bee77d8832da5384346c4a318bd