### PR TITLE
Fix approval buttons markup

### DIFF
--- a/templates/approve_physios.html
+++ b/templates/approve_physios.html
@@ -21,14 +21,13 @@
                     <td>{{ physio['email'] }}</td>
                     <td>{{ physio['phone'] }}</td>
                     <td>
-                        <a href="/approve_user/{{ physio['id'] }}">
+                        <a href="/approve_user/{{ physio['id'] }}" style="display:inline-block;">
                             <button class="button">Approve</button>
-                            <form action="/reject_user/{{ physio['id'] }}" method="get" style="display:inline;">
-                                {{ csrf_token() }}
-                                <button class="button" style="background-color: crimson;">Reject</button>
-                            </form>
-
                         </a>
+                        <form action="/reject_user/{{ physio['id'] }}" method="get" style="display:inline;">
+                            {{ csrf_token() }}
+                            <button class="button" style="background-color: crimson;">Reject</button>
+                        </form>
                     </td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
## Summary
- separate the Approve link from the Reject form on the physio approval table
- keep CSRF token in the reject form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68679f9d87d0832d9b0d807a38262338