### PR TITLE
Add patient timestamp

### DIFF
--- a/app.py
+++ b/app.py
@@ -582,7 +582,8 @@ def add_patient():
                 'age_sex': age_sex,
                 'contact': contact,
                 'present_history': present_history,
-                'past_history': past_history
+                'past_history': past_history,
+                'created_at': firestore.SERVER_TIMESTAMP
             })
             return new_id
 

--- a/templates/view_patients.html
+++ b/templates/view_patients.html
@@ -113,7 +113,13 @@
                     <td>{{ patient.name }}</td>
                     <td>{{ patient.age_sex }}</td>
                     <td>{{ patient.contact }}</td>
-                    <td>{{ patient.created_at }}</td>
+                    <td>
+                        {% if patient.created_at %}
+                            {{ patient.created_at.strftime('%Y-%m-%d %H:%M') }}
+                        {% else %}
+                            N/A
+                        {% endif %}
+                    </td>
                     <td style="display: flex; flex-direction: column; gap: 4px;">
                         <!-- Existing Actions -->
                         <a href="/edit_patient/{{ patient.patient_id }}"><button class="button">Edit</button></a>


### PR DESCRIPTION
## Summary
- include `created_at` when storing patient documents
- show formatted creation time in patient list

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867a02ba8e0832da162a2bb1b74a018