### PR TITLE
Use POST for admin user actions

### DIFF
--- a/app.py
+++ b/app.py
@@ -419,7 +419,7 @@ def export_audit_logs():
     return response
 
 
-@app.route('/reject_user/<user_id>')
+@app.route('/reject_user/<user_id>', methods=['POST'])
 @login_required()
 def reject_user(user_id):
     if session.get('is_admin') != 1:
@@ -484,7 +484,7 @@ def register_with_institute():
 
     return render_template('register_with_institute.html', institutes=institutes)
 
-@app.route('/approve_user/<user_id>')
+@app.route('/approve_user/<user_id>', methods=['POST'])
 @login_required()
 def approve_user(user_id):
     if session.get('is_admin') != 1:
@@ -526,7 +526,7 @@ def manage_users():
 
     return render_template('manage_users.html', users=user_list)
 
-@app.route('/deactivate_user/<user_id>')
+@app.route('/deactivate_user/<user_id>', methods=['POST'])
 @login_required()
 def deactivate_user(user_id):
     if session.get('is_admin') != 1:
@@ -542,7 +542,7 @@ def deactivate_user(user_id):
 
     return redirect('/manage_users')
 
-@app.route('/reactivate_user/<user_id>')
+@app.route('/reactivate_user/<user_id>', methods=['POST'])
 @login_required()
 def reactivate_user(user_id):
     if session.get('is_admin') != 1:

--- a/templates/approve_physios.html
+++ b/templates/approve_physios.html
@@ -21,10 +21,11 @@
                     <td>{{ physio['email'] }}</td>
                     <td>{{ physio['phone'] }}</td>
                     <td>
-                        <a href="/approve_user/{{ physio['id'] }}" style="display:inline-block;">
+                        <form action="/approve_user/{{ physio['id'] }}" method="post" style="display:inline;">
+                            {{ csrf_token() }}
                             <button class="button">Approve</button>
-                        </a>
-                        <form action="/reject_user/{{ physio['id'] }}" method="get" style="display:inline;">
+                        </form>
+                        <form action="/reject_user/{{ physio['id'] }}" method="post" style="display:inline;">
                             {{ csrf_token() }}
                             <button class="button" style="background-color: crimson;">Reject</button>
                         </form>

--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -29,13 +29,15 @@
                 </td>
                 <td>
                     {% if user['active'] %}
-                        <a href="/deactivate_user/{{ user['id'] }}">
+                        <form action="/deactivate_user/{{ user['id'] }}" method="post" style="display:inline;">
+                            {{ csrf_token() }}
                             <button style="background-color: crimson;">Deactivate</button>
-                        </a>
+                        </form>
                     {% else %}
-                        <a href="/reactivate_user/{{ user['id'] }}">
+                        <form action="/reactivate_user/{{ user['id'] }}" method="post" style="display:inline;">
+                            {{ csrf_token() }}
                             <button>Reactivate</button>
-                        </a>
+                        </form>
                     {% endif %}
                 </td>
             </tr>


### PR DESCRIPTION
## Summary
- switch `approve_user`, `reject_user`, `deactivate_user` and `reactivate_user` routes to POST-only
- update templates to submit POST forms with CSRF tokens for those routes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a0d3fd58832d82a1bf0f3ef1dc44